### PR TITLE
🐛 Add @types dependencies

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ type ExtractIdType<TSchema> = TSchema extends { _id: infer U }
       : U
   : mongodb.ObjectId
 
+type FlattenIfArray<T> = T extends Array<infer R> ? R : T
 type OptionalId<TSchema> = Omit<TSchema, '_id'> & { _id?: any }
 type WithId<TSchema> = Omit<TSchema, '_id'> & { _id: ExtractIdType<TSchema> }
 
@@ -23,7 +24,7 @@ declare namespace albatross {
 
     count (query?: mongodb.FilterQuery<TSchema>, options?: mongodb.MongoCountPreferences): Promise<number>
 
-    distinct<Key extends keyof WithId<TSchema>> (key: Key, query?: mongodb.FilterQuery<TSchema>, options?: { readPreference?: mongodb.ReadPreference | string, maxTimeMS?: number, session?: mongodb.ClientSession }): Promise<Array<WithId<TSchema>[Key]>>
+    distinct<Key extends keyof WithId<TSchema>> (key: Key, query?: mongodb.FilterQuery<TSchema>, options?: { readPreference?: mongodb.ReadPreference | string, maxTimeMS?: number, session?: mongodb.ClientSession }): Promise<Array<FlattenIfArray<WithId<TSchema>[Key]>>>
     distinct (key: string, query?: mongodb.FilterQuery<TSchema>, options?: { readPreference?: mongodb.ReadPreference | string, maxTimeMS?: number, session?: mongodb.ClientSession }): Promise<any[]>
 
     exists (query?: mongodb.FilterQuery<TSchema>): Promise<boolean>

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "tsc": "tsc --noEmit --allowJs --checkJs index.d.ts test/*.js"
   },
   "dependencies": {
+    "@types/bson": "1.0.11",
+    "@types/mongodb": "3.5.20",
     "bson": "^1.1.1",
     "debug": "^4.1.1",
     "mongodb": "^3.5.4"
   },
   "devDependencies": {
-    "@types/bson": "^1.0.11",
     "@types/mocha": "^5.2.7",
-    "@types/mongodb": "^3.3.12",
     "@types/node": "^8.10.54",
     "assert-rejects": "^1.0.0",
     "get-stream": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@types/bson": "1.0.11",
-    "@types/mongodb": "3.5.20",
+    "@types/mongodb": "3.5.10",
     "bson": "^1.1.1",
     "debug": "^4.1.1",
     "mongodb": "^3.5.4"


### PR DESCRIPTION
The reason for pinning these is that DefinitelyTyped releases breaking changes in patch releases, so with the pinning we can go thru and make sure that our types doesn't break from any changes upstream...