### PR TITLE
🎉 MongoDB driver 3.6 and TypeScript improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,25 +1,30 @@
 import * as mongodb from 'mongodb'
 
 type FlattenIfArray<T> = T extends Array<infer R> ? R : T
+type RequiredProjection<T extends { projection?: any }> = T & { projection: NonNullable<T['projection']> }
+type SpecificProjection<T extends { projection?: any }, TProjection> = Omit<T, 'projection'> & { projection: TProjection }
 type WithoutProjection<T> = T & { fields?: undefined, projection?: undefined }
-type WithProjection<T extends { projection?: any }> = T & { projection: NonNullable<T['projection']> }
 
 declare function albatross (uri: string): albatross.Albatross
 
 declare namespace albatross {
-  interface Collection<TSchema> {
+  interface Collection<TSchema extends { _id: any }> {
     readonly parent: Albatross
     id (hexString?: mongodb.ObjectId | string): mongodb.ObjectId
 
     findOne (filter: mongodb.FilterQuery<TSchema>, options?: WithoutProjection<mongodb.FindOneOptions<TSchema>>): Promise<TSchema | null>
-    findOne (filter: mongodb.FilterQuery<TSchema>, options: WithProjection<mongodb.FindOneOptions<TSchema>>): Promise<object | null>
+    findOne<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey> | null>
+    findOne<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
+    findOne (filter: mongodb.FilterQuery<TSchema>, options: RequiredProjection<mongodb.FindOneOptions<TSchema>>): Promise<object | null>
 
     find (query: mongodb.FilterQuery<TSchema>, options?: WithoutProjection<mongodb.FindOneOptions<TSchema>>): Promise<TSchema[]>
-    find (query: mongodb.FilterQuery<TSchema>, options: WithProjection<mongodb.FindOneOptions<TSchema>>): Promise<object[]>
+    find<TKey extends keyof TSchema> (query: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Array<Pick<TSchema, TKey>>>
+    find<TKey extends keyof TSchema> (query: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Array<Pick<TSchema, '_id' | TKey>>>
+    find (query: mongodb.FilterQuery<TSchema>, options: RequiredProjection<mongodb.FindOneOptions<TSchema>>): Promise<object[]>
 
     count (query?: mongodb.FilterQuery<TSchema>, options?: mongodb.MongoCountPreferences): Promise<number>
 
-    distinct<Key extends keyof mongodb.WithId<TSchema>> (key: Key, query?: mongodb.FilterQuery<TSchema>, options?: { readPreference?: mongodb.ReadPreference | string, maxTimeMS?: number, session?: mongodb.ClientSession }): Promise<Array<FlattenIfArray<mongodb.WithId<TSchema>[Key]>>>
+    distinct<TKey extends keyof mongodb.WithId<TSchema>> (key: TKey, query?: mongodb.FilterQuery<TSchema>, options?: { readPreference?: mongodb.ReadPreference | string, maxTimeMS?: number, session?: mongodb.ClientSession }): Promise<Array<FlattenIfArray<mongodb.WithId<TSchema>[TKey]>>>
     distinct (key: string, query?: mongodb.FilterQuery<TSchema>, options?: { readPreference?: mongodb.ReadPreference | string, maxTimeMS?: number, session?: mongodb.ClientSession }): Promise<any[]>
 
     exists (query?: mongodb.FilterQuery<TSchema>): Promise<boolean>
@@ -30,8 +35,14 @@ declare namespace albatross {
     findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: WithoutProjection<mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }>): Promise<TSchema>
     findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: WithoutProjection<mongodb.FindOneAndUpdateOption<TSchema>>): Promise<TSchema | null>
 
-    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: WithProjection<mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }>): Promise<object>
-    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: WithProjection<mongodb.FindOneAndUpdateOption<TSchema>>): Promise<object | null>
+    findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: SpecificProjection<mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey>>
+    findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: SpecificProjection<mongodb.FindOneAndUpdateOption<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey> | null>
+
+    findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: SpecificProjection<mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey>>
+    findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: SpecificProjection<mongodb.FindOneAndUpdateOption<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
+
+    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: RequiredProjection<mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }>): Promise<object>
+    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: RequiredProjection<mongodb.FindOneAndUpdateOption<TSchema>>): Promise<object | null>
 
     updateOne (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.UpdateOneOptions): Promise<{ matched: 0 | 1, modified: 0 | 1 }>
     updateMany (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.UpdateManyOptions): Promise<{ matched: number, modified: number }>
@@ -63,7 +74,7 @@ declare namespace albatross {
 
   interface Albatross {
     id (hexString?: mongodb.ObjectId | string): mongodb.ObjectId
-    collection<TSchema> (name: string): Collection<TSchema>
+    collection<TSchema extends { _id: any }> (name: string): Collection<TSchema>
     grid (name?: string): Grid
     ping (timeout?: number): Promise<void>
     close (force?: boolean): Promise<void>

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,8 @@ declare namespace albatross {
     readonly parent: Albatross
     id (hexString?: mongodb.ObjectId | string): mongodb.ObjectId
 
-    findOne<T = TSchema> (filter: mongodb.FilterQuery<TSchema>, options?: mongodb.FindOneOptions): Promise<T | null>
-    find<T = TSchema> (query: mongodb.FilterQuery<TSchema>, options?: mongodb.FindOneOptions): Promise<T[]>
+    findOne<T = TSchema> (filter: mongodb.FilterQuery<TSchema>, options?: mongodb.FindOneOptions<TSchema>): Promise<T | null>
+    find<T = TSchema> (query: mongodb.FilterQuery<TSchema>, options?: mongodb.FindOneOptions<TSchema>): Promise<T[]>
 
     count (query?: mongodb.FilterQuery<TSchema>, options?: mongodb.MongoCountPreferences): Promise<number>
 
@@ -22,8 +22,8 @@ declare namespace albatross {
     insert (doc: mongodb.OptionalId<TSchema>, options?: mongodb.CollectionInsertOneOptions): Promise<mongodb.WithId<TSchema>>
     insert (docs: mongodb.OptionalId<TSchema>[], options?: mongodb.CollectionInsertManyOptions): Promise<mongodb.WithId<TSchema>[]>
 
-    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: mongodb.FindOneAndUpdateOption & { returnOriginal: false, upsert: true }): Promise<TSchema>
-    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.FindOneAndUpdateOption): Promise<TSchema | null>
+    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }): Promise<TSchema>
+    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.FindOneAndUpdateOption<TSchema>): Promise<TSchema | null>
 
     updateOne (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.UpdateOneOptions): Promise<{ matched: 0 | 1, modified: 0 | 1 }>
     updateMany (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.UpdateManyOptions): Promise<{ matched: number, modified: number }>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,7 @@
 import * as mongodb from 'mongodb'
 
 type FlattenIfArray<T> = T extends Array<infer R> ? R : T
-type RequiredProjection<T extends { projection?: any }> = T & { projection: NonNullable<T['projection']> }
-type SpecificProjection<T extends { projection?: any }, TProjection> = Omit<T, 'projection'> & { projection: TProjection }
+type SpecificProjection<T, TProjection> = Omit<T, 'projection'> & { projection: TProjection }
 type WithoutProjection<T> = T & { fields?: undefined, projection?: undefined }
 
 declare function albatross (uri: string): albatross.Albatross
@@ -15,12 +14,12 @@ declare namespace albatross {
     findOne (filter: mongodb.FilterQuery<TSchema>, options?: WithoutProjection<mongodb.FindOneOptions<TSchema>>): Promise<TSchema | null>
     findOne<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey> | null>
     findOne<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
-    findOne (filter: mongodb.FilterQuery<TSchema>, options: RequiredProjection<mongodb.FindOneOptions<TSchema>>): Promise<object | null>
+    findOne (filter: mongodb.FilterQuery<TSchema>, options: mongodb.FindOneOptions<TSchema>): Promise<object | null>
 
     find (query: mongodb.FilterQuery<TSchema>, options?: WithoutProjection<mongodb.FindOneOptions<TSchema>>): Promise<TSchema[]>
     find<TKey extends keyof TSchema> (query: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Array<Pick<TSchema, TKey>>>
     find<TKey extends keyof TSchema> (query: mongodb.FilterQuery<TSchema>, options: SpecificProjection<mongodb.FindOneOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Array<Pick<TSchema, '_id' | TKey>>>
-    find (query: mongodb.FilterQuery<TSchema>, options: RequiredProjection<mongodb.FindOneOptions<TSchema>>): Promise<object[]>
+    find (query: mongodb.FilterQuery<TSchema>, options: mongodb.FindOneOptions<TSchema>): Promise<object[]>
 
     count (query?: mongodb.FilterQuery<TSchema>, options?: mongodb.MongoCountPreferences): Promise<number>
 
@@ -41,8 +40,8 @@ declare namespace albatross {
     findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: SpecificProjection<mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey>>
     findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: SpecificProjection<mongodb.FindOneAndUpdateOption<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
 
-    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: RequiredProjection<mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }>): Promise<object>
-    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: RequiredProjection<mongodb.FindOneAndUpdateOption<TSchema>>): Promise<object | null>
+    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options: mongodb.FindOneAndUpdateOption<TSchema> & { returnOriginal: false, upsert: true }): Promise<object>
+    findOneAndUpdate (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.FindOneAndUpdateOption<TSchema>): Promise<object | null>
 
     updateOne (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.UpdateOneOptions): Promise<{ matched: 0 | 1, modified: 0 | 1 }>
     updateMany (filter: mongodb.FilterQuery<TSchema>, update: mongodb.UpdateQuery<TSchema> | Partial<TSchema>, options?: mongodb.UpdateManyOptions): Promise<{ matched: number, modified: number }>

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "@types/bson": "1.0.11",
-    "@types/mongodb": "3.5.25",
-    "bson": "^1.1.1",
+    "@types/mongodb": "3.6.5",
+    "bson": "^1.1.4",
     "debug": "^4.1.1",
-    "mongodb": "^3.5.4"
+    "mongodb": "^3.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/test/collection.js
+++ b/test/collection.js
@@ -7,10 +7,20 @@ const albatross = require('../')
 const id = crypto.randomBytes(4).toString('hex')
 const ObjectId = albatross.ObjectId
 
+/**
+ * @typedef {Object} User
+ * @property {import('bson').ObjectId} _id
+ * @property {boolean} [famous]
+ * @property {string[]} [fruits]
+ * @property {string} name
+ * @property {string} [planet]
+ * @property {number} [year]
+ */
+
 describe('Collection', () => {
   /** @type {import('../').Albatross} */
   let db
-  /** @type {import('../').Collection} */
+  /** @type {import('../').Collection<User>} */
   let user
   /** @type {import('../').ObjectId} */
   let linusId
@@ -39,7 +49,7 @@ describe('Collection', () => {
 
   describe('#aggregate', () => {
     it('should find one record', async () => {
-      const docs = await user.aggregate([{ $match: { name: 'Linus' } }])
+      const docs = /** @type {User[]} */ (await user.aggregate([{ $match: { name: 'Linus' } }]))
       assert.ok(docs)
       assert.ok(Array.isArray(docs))
       assert.strictEqual(docs.length, 1)
@@ -47,11 +57,11 @@ describe('Collection', () => {
     })
 
     it('should perform some pipeline stages', async () => {
-      const docs = await user.aggregate([
+      const docs = /** @type {{ _id: string, total: number }[]} */ (await user.aggregate([
         { $match: { name: { $ne: 'Linus' } } },
         { $group: { _id: '$name', total: { $sum: 1 } } },
         { $sort: { _id: 1 } }
-      ])
+      ]))
       assert.ok(docs)
       assert.ok(Array.isArray(docs))
       assert.strictEqual(docs.length, 2)
@@ -227,21 +237,21 @@ describe('Collection', () => {
 
   describe('#insert', () => {
     it('should insert a single document', async () => {
-      const doc = await user.insert({ test: 'foo' })
+      const doc = await user.insert({ name: 'foo' })
       assert.ok(doc)
-      assert.strictEqual(doc.test, 'foo')
+      assert.strictEqual(doc.name, 'foo')
     })
 
     it('should insert multiple documents', async () => {
-      const docs = await user.insert([{ test: 'foo' }, { test: 'bar' }])
+      const docs = await user.insert([{ name: 'foo' }, { name: 'bar' }])
       assert.ok(Array.isArray(docs))
       assert.strictEqual(docs.length, 2)
-      assert.strictEqual(docs[0].test, 'foo')
-      assert.strictEqual(docs[1].test, 'bar')
+      assert.strictEqual(docs[0].name, 'foo')
+      assert.strictEqual(docs[1].name, 'bar')
     })
 
     it('should give inserted document', async () => {
-      const a = { test: 'foo' }
+      const a = { name: 'foo' }
       const b = await user.insert(a)
 
       // @ts-ignore
@@ -252,7 +262,7 @@ describe('Collection', () => {
     })
 
     it('should give inserted documents', async () => {
-      const a = [{ test: 'foo' }, { test: 'bar' }]
+      const a = [{ name: 'foo' }, { name: 'bar' }]
       const b = await user.insert(a)
 
       // @ts-ignore


### PR DESCRIPTION
Before this change `aggregate`, `find`, `findOne`, and `findOneAndUpdate` would act like they could return whatever you wanted. This meant that passing the return value of any of those functions into e.g. another function that expecteded something else would be accepted.

Since this is now fixed you could potentially encounter some problems with TypeScript, but the previous behaviour was unsound which is why I think this is okay to fix in a minor release.