### PR TITLE
💥 Upgrade to MongoDB Node.js driver 5.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,15 @@ on:
   pull_request:
     branches:
     - master
+    - v5.x
 
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [12.20.0, 14.13.1, 16.0.0]
-        mongodb: [4.4, 6.0]
+        node: [14.20.1, 16.0.0, 18.0.0]
+        mongodb: [6.0, 7.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2021 Linus Unnebäck
+Copyright (c) 2014-2025 Linus Unnebäck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,43 +20,43 @@ export interface Collection<TSchema extends { _id: any }> {
   readonly parent: Albatross
   id (hexString?: mongodb.ObjectId | string): mongodb.ObjectId
 
-  findOne (filter: mongodb.Filter<TSchema>, options?: WithoutProjection<mongodb.FindOptions<TSchema>>): Promise<TSchema | null>
-  findOne<TKey extends keyof TSchema> (filter: mongodb.Filter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey> | null>
-  findOne<TKey extends keyof TSchema> (filter: mongodb.Filter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
-  findOne (filter: mongodb.Filter<TSchema>, options: mongodb.FindOptions<TSchema>): Promise<object | null>
+  findOne (filter: mongodb.StrictFilter<TSchema>, options?: WithoutProjection<mongodb.FindOptions<TSchema>>): Promise<TSchema | null>
+  findOne<TKey extends keyof TSchema> (filter: mongodb.StrictFilter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey> | null>
+  findOne<TKey extends keyof TSchema> (filter: mongodb.StrictFilter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
+  findOne (filter: mongodb.StrictFilter<TSchema>, options: mongodb.FindOptions<TSchema>): Promise<object | null>
 
-  find (query: mongodb.Filter<TSchema>, options?: WithoutProjection<mongodb.FindOptions<TSchema>>): Promise<TSchema[]>
-  find<TKey extends keyof TSchema> (query: mongodb.Filter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Array<Pick<TSchema, TKey>>>
-  find<TKey extends keyof TSchema> (query: mongodb.Filter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Array<Pick<TSchema, '_id' | TKey>>>
-  find (query: mongodb.Filter<TSchema>, options: mongodb.FindOptions<TSchema>): Promise<object[]>
+  find (query: mongodb.StrictFilter<TSchema>, options?: WithoutProjection<mongodb.FindOptions<TSchema>>): Promise<TSchema[]>
+  find<TKey extends keyof TSchema> (query: mongodb.StrictFilter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Array<Pick<TSchema, TKey>>>
+  find<TKey extends keyof TSchema> (query: mongodb.StrictFilter<TSchema>, options: SpecificProjection<mongodb.FindOptions<TSchema>, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Array<Pick<TSchema, '_id' | TKey>>>
+  find (query: mongodb.StrictFilter<TSchema>, options: mongodb.FindOptions<TSchema>): Promise<object[]>
 
-  count (query?: mongodb.Filter<TSchema>, options?: mongodb.CountOptions): Promise<number>
+  count (query?: mongodb.StrictFilter<TSchema>, options?: mongodb.CountOptions): Promise<number>
 
-  distinct<TKey extends keyof mongodb.WithId<TSchema>> (key: TKey, query?: mongodb.Filter<TSchema>, options?: mongodb.DistinctOptions): Promise<Array<mongodb.Flatten<mongodb.WithId<TSchema>[TKey]>>>
-  distinct (key: string, query?: mongodb.Filter<TSchema>, options?: mongodb.DistinctOptions): Promise<any[]>
+  distinct<TKey extends keyof mongodb.WithId<TSchema>> (key: TKey, query?: mongodb.StrictFilter<TSchema>, options?: mongodb.DistinctOptions): Promise<Array<mongodb.Flatten<mongodb.WithId<TSchema>[TKey]>>>
+  distinct (key: string, query?: mongodb.StrictFilter<TSchema>, options?: mongodb.DistinctOptions): Promise<any[]>
 
-  exists (query?: mongodb.Filter<TSchema>, options?: { hint?: mongodb.Hint }): Promise<boolean>
+  exists (query?: mongodb.StrictFilter<TSchema>, options?: { hint?: mongodb.Hint }): Promise<boolean>
 
   insert (doc: DeepReadonly<mongodb.OptionalId<TSchema>>, options?: mongodb.InsertOneOptions): Promise<mongodb.WithId<TSchema>>
   insert (docs: DeepReadonly<mongodb.OptionalId<TSchema>>[], options?: mongodb.BulkWriteOptions): Promise<mongodb.WithId<TSchema>[]>
 
-  findOneAndUpdate (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options: WithoutProjection<FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }>): Promise<TSchema>
-  findOneAndUpdate (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options?: WithoutProjection<FindOneAndUpdateOptions>): Promise<TSchema | null>
+  findOneAndUpdate (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options: WithoutProjection<FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }>): Promise<TSchema>
+  findOneAndUpdate (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options?: WithoutProjection<FindOneAndUpdateOptions>): Promise<TSchema | null>
 
-  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey>>
-  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey> | null>
+  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey>>
+  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions, { [key in TKey]: 1 | true } & { _id: 0 | false }>): Promise<Pick<TSchema, TKey> | null>
 
-  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey>>
-  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
+  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey>>
+  findOneAndUpdate<TKey extends keyof TSchema> (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options: SpecificProjection<FindOneAndUpdateOptions, { [key in TKey]: 1 | true } & { _id?: 1 | true }>): Promise<Pick<TSchema, '_id' | TKey> | null>
 
-  findOneAndUpdate (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options: FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }): Promise<object>
-  findOneAndUpdate (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options?: FindOneAndUpdateOptions): Promise<object | null>
+  findOneAndUpdate (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options: FindOneAndUpdateOptions & { returnDocument: 'after', upsert: true }): Promise<object>
+  findOneAndUpdate (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options?: FindOneAndUpdateOptions): Promise<object | null>
 
-  updateOne (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema> | Partial<TSchema>, options?: mongodb.UpdateOptions): Promise<{ matched: 0 | 1, modified: 0 | 1 }>
-  updateMany (filter: mongodb.Filter<TSchema>, update: mongodb.UpdateFilter<TSchema>, options?: mongodb.UpdateOptions): Promise<{ matched: number, modified: number }>
+  updateOne (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema> | Partial<TSchema>, options?: mongodb.UpdateOptions): Promise<{ matched: 0 | 1, modified: 0 | 1 }>
+  updateMany (filter: mongodb.StrictFilter<TSchema>, update: mongodb.StrictUpdateFilter<TSchema>, options?: mongodb.UpdateOptions): Promise<{ matched: number, modified: number }>
 
-  deleteOne (filter: mongodb.Filter<TSchema>, options?: mongodb.DeleteOptions): Promise<0 | 1>
-  deleteMany (filter: mongodb.Filter<TSchema>, options?: mongodb.DeleteOptions): Promise<number>
+  deleteOne (filter: mongodb.StrictFilter<TSchema>, options?: mongodb.DeleteOptions): Promise<0 | 1>
+  deleteMany (filter: mongodb.StrictFilter<TSchema>, options?: mongodb.DeleteOptions): Promise<number>
 
   aggregate (pipeline: object[], options?: mongodb.AggregateOptions): Promise<object[]>
 

--- a/lib/albatross.js
+++ b/lib/albatross.js
@@ -51,7 +51,7 @@ export default class Albatross {
 
     try {
       if (typeof timeout === 'number') {
-        const timeoutPromise = new Promise((resolve, reject) => {
+        const timeoutPromise = new Promise((_resolve, reject) => {
           timeoutHandle = setTimeout(() => {
             timeoutHandle = null
             reject(new Error('Timeout reached while waiting for ping'))

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,10 +1,10 @@
-import BSON from 'bson'
+import { deserialize, serialize } from 'bson'
 import debug from 'debug'
 
 const kDebug = Symbol('debug')
 
 function prepareDocument (document) {
-  return BSON.deserialize(BSON.serialize(document), { promoteValues: true })
+  return deserialize(serialize(document), { promoteValues: true })
 }
 
 export default class Collection {

--- a/lib/grid.js
+++ b/lib/grid.js
@@ -70,10 +70,7 @@ export default class Grid {
 
   async delete (id) {
     const db = await this.parent.db()
-
-    return new Promise((resolve, reject) => {
-      const bucket = new mongodb.GridFSBucket(db, { bucketName: this.name })
-      bucket.delete(this.id(id), (err) => err ? reject(err) : resolve())
-    })
+    const bucket = new mongodb.GridFSBucket(db, { bucketName: this.name })
+    await bucket.delete(this.id(id))
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
     "tsc": "tsc --allowSyntheticDefaultImports --noEmit --allowJs --checkJs index.d.ts test/*.js"
   },
   "dependencies": {
-    "bson": "^4.7.0",
-    "debug": "^4.3.4",
-    "mongodb": "^4.9.0"
+    "bson": "^5.5.1",
+    "debug": "^4.4.1",
+    "mongodb": "^5.9.2"
   },
   "devDependencies": {
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^16.4.13",
     "get-stream": "^6.0.1",
-    "mocha": "^9.0.3",
+    "mocha": "^10.8.2",
     "standard": "^17.0.0",
-    "typescript": "^4.8.2"
+    "typescript": "^5.8.3"
   },
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": "^14.20.1 || >=16.0.0"
   }
 }


### PR DESCRIPTION
Migration Guide:

- The minimum version of Node.js supported is now: `14.20.1`, and `16.0.0`

- `bson-ext` support removed

    The `bson-ext` package will no longer automatically import and supplant the bson dependency.

- `@aws-sdk/credential-providers` v3.201.0 or later and optional `peerDependency`

    `@aws-sdk/credential-providers` has been added to the `package.json` as a `peerDependency` that is **optional**. This means `npm` will let you know if the version of the SDK you have installed is incompatible with the driver.

- Snappy v7.2.2 or later and optional `peerDependency`

    `snappy` compression has been added to the `package.json` as a `peerDependency` that is **optional**. This means `npm` will let you know if the version of `snappy` you have installed is incompatible with the driver.