### PR TITLE
💥 Upgrade to MongoDB Node.js driver 6.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,24 +4,24 @@ on:
   pull_request:
     branches:
     - master
-    - v5.x
+    - v6.x
 
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14.20.1, 16.0.0, 18.0.0]
-        mongodb: [6.0, 7.0]
+        node: [16.20.1, 18.0.0, 20.0.0, 22.0.0, 24.0.0]
+        mongodb: [6.0, 7.0, 8.0]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node }}
     - name: Start MongoDB
-      uses: supercharge/mongodb-github-action@1.8.0
+      uses: supercharge/mongodb-github-action@1.12.1
       with:
         mongodb-replica-set: test
         mongodb-version: ${{ matrix.mongodb }}

--- a/lib/albatross.js
+++ b/lib/albatross.js
@@ -72,17 +72,13 @@ export default class Albatross {
   async transaction (fn) {
     const session = this[kClient].startSession()
 
-    let result
-
     try {
-      await session.withTransaction(async (...args) => {
-        result = await fn(...args)
+      return await session.withTransaction(async (...args) => {
+        return await fn(...args)
       })
     } finally {
       session.endSession()
     }
-
-    return result
   }
 
   async close (force) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -127,7 +127,7 @@ export default class Collection {
       this[kDebug]('findOneAndUpdate(%o, %o)', filter, update)
       const res = await db.collection(this.name).findOneAndUpdate(filter, update, opts)
       this[kDebug]('reply OK')
-      return res.value
+      return res
     } catch (err) {
       this[kDebug]('reply ERR')
       throw err

--- a/lib/grid.js
+++ b/lib/grid.js
@@ -37,7 +37,7 @@ export default class Grid {
       const upload = bucket.openUploadStream(opts.filename || '', opts)
 
       upload.on('error', reject)
-      upload.on('finish', (file) => resolve(fileInfo(file)))
+      upload.on('finish', () => resolve(fileInfo(upload.gridFSFile)))
 
       stream.pipe(upload)
     })

--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
     "tsc": "tsc --allowSyntheticDefaultImports --noEmit --allowJs --checkJs index.d.ts test/*.js"
   },
   "dependencies": {
-    "bson": "^5.5.1",
-    "debug": "^4.4.1",
-    "mongodb": "^5.9.2"
+    "bson": "^6.10.4",
+    "debug": "^4.4.3",
+    "mongodb": "^6.21.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@types/node": "^16.4.13",
-    "get-stream": "^6.0.1",
+    "@types/node": "^16.18.126",
+    "get-stream": "^7.0.1",
     "mocha": "^10.8.2",
-    "standard": "^17.0.0",
-    "typescript": "^5.8.3"
+    "standard": "^17.1.2",
+    "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "^14.20.1 || >=16.0.0"
+    "node": "^16.20.1 || >=18.0.0"
   }
 }


### PR DESCRIPTION
Migration Guide:

- The minimum version of Node.js supported is now: `16.20.1`

- BSON version 6.x

    This driver version has been updated to use `bson@6`. BSON functionality re-exported from the driver is subject to the changes outlined in the [BSON V6 release notes](https://github.com/mongodb/js-bson/releases/tag/v6.0.0).

- Optional peer dependency version bumps

    - `kerberos` optional peer dependency minimum version raised to `2.0.1`, dropped support for `1.x`
    - `zstd` optional peer dependency minimum version raised to `1.1.0` from `1.0.0`
    - `mongodb-client-encryption` optional peer dependency minimum version raised to `6.0.0` from `2.3.0` (note that `mongodb-client-encryption` does not have `3.x-5.x` version releases)

- Allow `socks` to be installed optionally

    The driver uses the `socks` dependency to connect to `mongod` or `mongos` through a [SOCKS5 proxy](https://en.wikipedia.org/wiki/SOCKS). `socks` used to be a required dependency of the driver and was installed automatically. Now, `socks` is a `peerDependency` that must be installed to enable `socks` proxy support.

- Boolean options only accept `true` or `false` in connection strings

    Prior to this change, we accepted the values `'1'`, `'y'`, `'yes'`, `'t'` as synonyms for true and `'-1'`, `'0'`, `'f'`, `'n'`, `'no'` as synonyms for false. These have now been removed in an effort to make working with connection string options simpler.

    ```js
    // Incorrect
    const db = albatross('mongodb://localhost:27017?tls=1'); // throws MongoParseError

    // Correct
    const db = albatross('mongodb://localhost:27017?tls=true');
    ```

- Repeated options are no longer allowed in connection strings

    In order to avoid accidental misconfiguration the driver will no longer prioritize the first instance of an option provided on the URI. Instead repeated options that are not permitted to be repeated will throw an error.

    This change will ensure that connection strings that contain options like `tls=true&tls=false` are no longer ambiguous.